### PR TITLE
Fixes for JRuby compatibility

### DIFF
--- a/lib/om/xml/term_value_operators.rb
+++ b/lib/om/xml/term_value_operators.rb
@@ -161,7 +161,7 @@ module OM::XML::TermValueOperators
     template.gsub!(/text\(\)/, 'text')
 
     #if the template doesn't specify a namespace prefix, use the parent node's prefix
-    if parent_node.namespace.present? and parent_node.namespace.prefix.present?
+    if parent_node.namespace and parent_node.namespace.prefix.present?
       template.gsub!(/xml\./,"xml[:#{parent_node.namespace.prefix}].")
     end
 

--- a/lib/om/xml/term_value_operators.rb
+++ b/lib/om/xml/term_value_operators.rb
@@ -159,7 +159,12 @@ module OM::XML::TermValueOperators
 
     #if there is an xpath element pointing to text() need to change to just 'text' so it references the text method for the parent node
     template.gsub!(/text\(\)/, 'text')
-    
+
+    #if the template doesn't specify a namespace prefix, use the parent node's prefix
+    if parent_node.namespace.present? and parent_node.namespace.prefix.present?
+      template.gsub!(/xml\./,"xml[:#{parent_node.namespace.prefix}].")
+    end
+
     builder = Nokogiri::XML::Builder.with(parent_node) do |xml|
       new_values.each do |builder_new_value|
         builder_new_value = builder_new_value.gsub(/'/, "\\\\'") # escape any apostrophes in the new value

--- a/spec/integration/element_value_spec.rb
+++ b/spec/integration/element_value_spec.rb
@@ -34,8 +34,8 @@ describe "element values" do
   <elementB>valB1</elementB>
   <elementB animal="vole">valB2</elementB>
   <elementC type="c type" animal="seagull">valC</elementC>
-  <elementD >valD1</elementC>
-  <elementD animal="seagull">valD2</elementC>
+  <elementD>valD1</elementD>
+  <elementD animal="seagull">valD2</elementD>
   <resource type="ead" id="coll.ead" objectId="hypatia:ead_file_asset_fixture">
     <file id="my_ead.xml" format="XML" mimetype="text/xml" size="47570">
       <checksum type="md5">123</checksum>

--- a/spec/unit/container_spec.rb
+++ b/spec/unit/container_spec.rb
@@ -42,7 +42,7 @@ describe "OM::XML::Container" do
     it "should accept Nokogiri nodes as input and leave them as-is" do
       parsed_xml = Nokogiri::XML::Document.parse("<foo><bar>1</bar></foo>")
       container1 = ContainerTest.from_xml(parsed_xml)
-      container1.ng_xml.should == parsed_xml
+      container1.ng_xml.should be_equivalent_to(parsed_xml)
     end
   end
   
@@ -61,7 +61,7 @@ describe "OM::XML::Container" do
     
     it 'should accept an optional Nokogiri::XML Document as an argument and insert its fields into that (functional test)' do
       doc = Nokogiri::XML::Document.parse("<test_xml/>")
-      subject.to_xml(doc).should == "<?xml version=\"1.0\"?>\n<test_xml>\n  <foo>\n    <bar>1</bar>\n  </foo>\n</test_xml>\n"
+      subject.to_xml(doc).should be_equivalent_to("<?xml version=\"1.0\"?>\n<test_xml>\n  <foo>\n    <bar>1</bar>\n  </foo>\n</test_xml>\n")
     end
     
     it 'should add to root of Nokogiri::XML::Documents, but add directly to the elements if a Nokogiri::XML::Node is passed in' do

--- a/spec/unit/term_value_operators_spec.rb
+++ b/spec/unit/term_value_operators_spec.rb
@@ -171,12 +171,12 @@ describe "OM::XML::TermValueOperators" do
     it "should do nothing if field key is a string (must be an array or symbol).  Will not accept xpath queries!" do
       xml_before = @article.to_xml
       @article.update_values( { "fubar"=>"the role" } ).should == {}
-      @article.to_xml.should == xml_before
+      @article.to_xml.should be_equivalent_to(xml_before)
     end
     it "should do nothing if there is no term corresponding to the given field key" do
       xml_before = @article.to_xml
       @article.update_values( { [{"fubar"=>"0"}]=>"the role" } ).should == {}
-      @article.to_xml.should == xml_before
+      @article.to_xml.should be_equivalent_to(xml_before)
     end
     
     it "should work for text fields" do 
@@ -281,9 +281,9 @@ describe "OM::XML::TermValueOperators" do
         :parent_index => :first,
         :template => [:person, :affiliation],
         :values => ["my new value", "another new value"] 
-      ).to_xml.should == expected_result
+      ).to_xml.should be_equivalent_to(expected_result)
       
-      @sample.find_by_terms(:person, {:first_name=>"Tim", :last_name=>"Berners-Lee"}).first.to_xml.should == expected_result
+      @sample.find_by_terms(:person, {:first_name=>"Tim", :last_name=>"Berners-Lee"}).first.to_xml.should be_equivalent_to(expected_result)
     end
     
     it "should support adding attribute values" do
@@ -325,7 +325,7 @@ describe "OM::XML::TermValueOperators" do
       @sample.ng_xml.xpath('//oxns:name[@type="personal" and position()=1]/oxns:role', @sample.ox_namespaces).length.should == 2
       @sample.ng_xml.xpath('//oxns:name[@type="personal" and position()=1]/oxns:role[last()]/oxns:roleTerm', @sample.ox_namespaces).first.text.should == "founder"
 
-      # @sample.find_by_terms_and_value(:person).first.to_xml.should == expected_result
+      # @sample.find_by_terms_and_value(:person).first.to_xml.should be_equivalent_to(expected_result)
     end
 	  
 	  it "should support more complex mixing & matching" do


### PR DESCRIPTION
These changes will prepare OM for full JRuby compatibility, but will depend on sparklemotion/nokogiri#1054, sparklemotion/nokogiri#1056, and sparklemotion/nokogiri#1057 being accepted and merged. For now, there is a merged combo of all three of those at [mbklein/nokogiri@om-fixes](https://github.com/mbklein/nokogiri/tree/om-fixes). It won't install automatically from within bundler, but you can do the following:
1. `git clone https://github.com/mbklein/nokogiri.git nokogiri-om`
2. `cd nokogiri-om`
3. `git checkout om-fixes`
4. Tell your ruby version manage to use jruby (I use `rbenv shell jruby-1.7.9`)
5. `rake compile` (and ignore all the warnings - as long as the last line of output starts with `install -c` you're good to go)
6. cd to your om source directory
7. Edit om's `Gemfile` and add `gem 'nokogiri', :path => '/path/to/nokogiri-om'`
8. Do whatever you did in Step 4 to activate jruby
9. `bundle install`
10. `bundle exec rake spec`

You can also `rake compile` nokogiri under MRI, and then re-do the steps 9 and 10 under MRI, to verify that these changes (both to OM and nokogiri) don't break anything that already worked.
