### PR TITLE
Updates the documentation to be in compliance with the Component Maintenance WG templates

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,36 @@
+The Samvera community is dedicated to providing a welcoming and
+positive experience for all its members, whether they are at a formal
+gathering, in a social setting, or taking part in activities online.
+The Samvera community welcomes participation from people all over the
+world and these members bring with them a wide variety of
+professional, personal and social backgrounds; whatever these may be,
+we treat colleagues with dignity and respect.
+
+Community members communicate primarily in English, though for many of
+them this is not their native language. We therefore strive to express
+ourselves simply and clearly remembering that unnecessary use of
+jargon and slang will be a barrier to understanding for many of our
+colleagues.  We are sensitive to the fact that the international
+nature of the community means that we span many different social norms
+around language and behaviour and we strive to conduct ourselves,
+online and in person, in ways that are unlikely to cause offence.
+
+Samvera conversations are often information-rich and intended to
+generate discussion and debate.  We discuss ideas from a standpoint of
+mutual respect and reasoned argument.
+
+Community members work together to promote a respectful and safe
+community. In the event that someone’s conduct is causing offence or
+distress, Samvera has a detailed
+[Anti-Harassment Policy and Protocol](https://wiki.duraspace.org/display/samvera/Anti-Harassment+Policy)
+which can be applied to address the problem. The first step in dealing
+with any serious misconduct is to contact a local meeting organizer,
+the
+[Samvera community helpers](https://wiki.duraspace.org/display/samvera/Samvera+Community+Helpers)
+([email](mailto:helpers@samvera.org)), a community member you
+trust, or the
+[Samvera Steering Group](https://wiki.duraspace.org/display/samvera/Samvera+Steering+Group+membership)
+immediately; at Samvera events, these people can be identified by
+distinctive name badges. The
+[Policy and Protocol](https://wiki.duraspace.org/display/samvera/Anti-Harassment+Policy)
+should be consulted for fuller details.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,21 +1,24 @@
 # How to Contribute
 
-We want your help to make Project Hydra great.
-There are a few guidelines that we need contributors to follow so that we can have a chance of keeping on top of things.
+We want your help to make the Samvera community great. There are a few guidelines
+that we need contributors to follow so that we can have a chance of
+keeping on top of things.
 
 ## Code of Conduct
 
-The Hydra community is dedicated to providing a welcoming and positive experience for all its
-members, whether they are at a formal gathering, in a social setting, or taking part in activities
-online.  Please see our [Code of Conduct](https://wiki.duraspace.org/display/hydra/Code+of+Conduct)
-for more information.
+The Samvera Community is dedicated to providing a welcoming and positive
+experience for all its members, whether they are at a formal gathering, in
+a social setting, or taking part in activities online. Please see our
+[Code of Conduct](CODE_OF_CONDUCT.md) for more information.
 
-## Hydra Project Intellectual Property Licensing and Ownership
+## Samvera Community Intellectual Property Licensing and Ownership
 
-All code contributors must have an Individual Contributor License Agreement (iCLA) on file with the Hydra Project Steering Group.
-If the contributor works for an institution, the institution must have a Corporate Contributor License Agreement (cCLA) on file.
+All code contributors must have an Individual Contributor License Agreement
+(iCLA) on file with the Samvera Steering Group. If the contributor works for
+an institution, the institution must have a Corporate Contributor License
+Agreement (cCLA) on file.
 
-https://wiki.duraspace.org/display/hydra/Hydra+Project+Intellectual+Property+Licensing+and+Ownership
+https://wiki.duraspace.org/display/samvera/Samvera+Community+Intellectual+Property+Licensing+and+Ownership
 
 You should also add yourself to the `CONTRIBUTORS.md` file in the root of the project.
 
@@ -31,7 +34,7 @@ You should also add yourself to the `CONTRIBUTORS.md` file in the root of the pr
 ### Reporting Issues
 
 * Make sure you have a [GitHub account](https://github.com/signup/free)
-* Submit a [Github issue](./issues) by:
+* Submit a [Github issue](https://github.com/samvera/om/issues) by:
   * Clearly describing the issue
     * Provide a descriptive summary
     * Explain the expected behavior
@@ -48,7 +51,7 @@ You should also add yourself to the `CONTRIBUTORS.md` file in the root of the pr
   * Please avoid working directly on the `master` branch.
   * You may find the [hub suite of commands](https://github.com/defunkt/hub) helpful
 * Make sure you have added sufficient tests and documentation for your changes.
-  * Test functionality with RSpec; est features / UI with Capybara.
+  * Test functionality with RSpec; Test features / UI with Capybara.
 * Run _all_ the tests to assure nothing else was accidentally broken.
 
 ### Documenting Code
@@ -60,15 +63,11 @@ You should also add yourself to the `CONTRIBUTORS.md` file in the root of the pr
   * If you don't know exactly what a bit of code does, it is extra likely that it needs to be documented. Take a stab at it and ask for feedback in your pull request. You can use the 'blame' button on GitHub to identify the original developer of the code and @mention them in your comment.
   * This work greatly increases the usability of the code base and supports the on-ramping of new committers.
   * We will all be understanding of one another's time constraints in this area.
-* YARD examples:
-  * [Hydra::Works::RemoveGenericFile](https://github.com/projecthydra-labs/hydra-works/blob/master/lib/hydra/works/services/generic_work/remove_generic_file.rb)
-  * [ActiveTriples::LocalName::Minter](https://github.com/ActiveTriples/active_triples-local_name/blob/master/lib/active_triples/local_name/minter.rb)
 * [Getting started with YARD](http://www.rubydoc.info/gems/yard/file/docs/GettingStarted.md)
 
 ### Committing changes
 
 * Make commits of logical units.
-  * Your commit should include a high level description of your work in HISTORY.textile
 * Check for unnecessary whitespace with `git diff --check` before committing.
 * Make sure your commit messages are [well formed](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
 * If you created an issue, you can close it by including "Closes #issue" in your commit message. See [Github's blog post for more details](https://github.com/blog/1386-closing-issues-via-commit-messages)
@@ -103,6 +102,10 @@ You should also add yourself to the `CONTRIBUTORS.md` file in the root of the pr
       long to fit in 72 characters
 ```
 
+* Make sure you have added the necessary tests for your changes.
+* Run _all_ the tests to assure nothing else was accidentally broken.
+* When you are ready to submit a pull request
+
 ### Submitting Changes
 
 * Read the article ["Using Pull Requests"](https://help.github.com/articles/using-pull-requests) on GitHub.
@@ -125,9 +128,7 @@ We adopted [Github's Pull Request Review](https://help.github.com/articles/about
 Common checks that may occur in our repositories:
 
 1. Travis CI - where our automated tests are running
-2. Hound CI - where we check for style violations
-3. Approval Required - Github enforces at least one person approve a pull request. Also, all reviewers that have chimed in must approve.
-4. CodeClimate - is our code remaining healthy (at least according to static code analysis)
+2. Approval Required - Github enforces at least one person approve a pull request. Also, all reviewers that have chimed in must approve.
 
 If one or more of the required checks failed (or are incomplete), the code should not be merged (and the UI will not allow it). If all of the checks have passed, then anyone on the project (including the pull request submitter) may merge the code.
 
@@ -144,16 +145,17 @@ First, the person contributing the code is putting themselves out there. Be mind
 This is your chance for a mentoring moment of another developer. Take time to give an honest and thorough review of what has changed. Things to consider:
 
   * Does the commit message explain what is going on?
-  * Does the code changes have tests? _Not all changes need new tests, some changes are refactors_
+  * Does the code changes have tests? _Not all changes need new tests, some changes are refactorings_
   * Do new or changed methods, modules, and classes have documentation?
   * Does the commit contain more than it should? Are two separate concerns being addressed in one commit?
   * Does the description of the new/changed specs match your understanding of what the spec is doing?
+  * Did the Travis tests complete successfully?
 
 If you are uncertain, bring other contributors into the conversation by assigning them as a reviewer.
 
 # Additional Resources
 
 * [General GitHub documentation](http://help.github.com/)
-* [GitHub pull request documentation](http://help.github.com/send-pull-requests/)
+* [GitHub pull request documentation](https://help.github.com/articles/about-pull-requests/)
 * [Pro Git](http://git-scm.com/book) is both a free and excellent book about Git.
 * [A Git Config for Contributing](http://ndlib.github.io/practices/my-typical-per-project-git-config/)

--- a/LICENSE
+++ b/LICENSE
@@ -1,15 +1,11 @@
-##########################################################################
-# Copyright (c) 2009 Matt Zumwalt
-# Additional copyright may be held by others, as reflected in the commit log
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+Copyright 2009 Matt Zumwalt
+Additional copyright may be held by others, as reflected in the commit history.
+ Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
-[![Build Status](https://travis-ci.org/projecthydra/om.png?branch=master)](https://travis-ci.org/projecthydra/om)
-[![Gem Version](https://badge.fury.io/rb/om.png)](http://badge.fury.io/rb/om)
+# om (Opinionated Metadata)
+
+[![Version](https://badge.fury.io/rb/om.png)](http://badge.fury.io/rb/om)
+[![Build Status](https://travis-ci.org/samvera/om.png?branch=master)](https://travis-ci.org/samvera/om)
 [![Coverage Status](https://coveralls.io/repos/github/samvera/om/badge.svg?branch=master)](https://coveralls.io/github/samvera/om?branch=master)
 
-# om (Opinionated Metadata)
+Jump In: [![Slack Status](http://slack.samvera.org/badge.svg)](http://slack.samvera.org/)
+
+# What is om?
 
 A library to help you tame sprawling XML schemas like MODS.
 
@@ -10,26 +14,28 @@ OM allows you to define a "terminology" to ease translation between XML and ruby
 
 OM "terms" are ruby symbols you define (in the terminology) that map specific XML content into ruby object attributes.
 
+## Product Owner & Maintenance
+ **om** is a Core Component of the Samvera community. The documentation for
+what this means can be found
+[here](http://samvera.github.io/core_components.html#requirements-for-a-core-component).
+ ### Product Owner
+ [Jon Cameron](https://github.com/joncameron)
+
 ## Tutorials & Reference
 
-* [Tame Your XML with OM](https://github.com/projecthydra/om/wiki/Tame-your-XML-with-OM)
-* [Common OM Patterns](https://github.com/projecthydra/om/blob/master/COMMON_OM_PATTERNS.md)
+* [Tame Your XML with OM](https://github.com/samvera/om/wiki/Tame-your-XML-with-OM)
+* [Common OM Patterns](https://github.com/samvera/om/blob/master/COMMON_OM_PATTERNS.md)
 
 ### Solrizing Documents
 
 The solrizer gem provides support for indexing XML documents into Solr based on OM Terminologies.  
-That process is documented in the [solrizer README](https://github.com/projecthydra/solrizer)
-
-## OM in the Wild
-
-We have a page on the Hydra wiki with a list of OM Terminologies in active use:
-[OM Terminologies in the Wild](https://wiki.duraspace.org/display/hydra/OM+Terminologies+in+the+Wild)
+That process is documented in the [solrizer README](https://github.com/samvera/solrizer)
 
 ## Acknowledgments
 
 ### Creator
 
-Matt Zumwalt ([MediaShelf](http://yourmediashelf.com))
+Matt Zumwalt (MediaShelf)
 
 ### Thanks To
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,5 @@
+If you would like to report an issue, first search [the list of issues](https://github.com/samvera/om/issues/) to see if someone else has already reported it, and then feel free to [create a new issue](https://github.com/samvera/om/issues/new).
+
+If you have questions or need help, please email [the Samvera community tech list](https://groups.google.com/forum/#!forum/samvera-tech) or stop by the #dev channel in [the Samvera community Slack team](https://wiki.duraspace.org/pages/viewpage.action?pageId=87460391#Getintouch!-Slack).
+
+You can learn more about the various Samvera communication channels on the [Get in touch!](https://wiki.duraspace.org/pages/viewpage.action?pageId=87460391) wiki page.


### PR DESCRIPTION
Resolves #71 by updating the README, license, contribution guidelines, code of conduct, and support documentation in compliance with the templates provided by the Core Component Maintenance Working Group.  Also resolves #64 (the link resolved to the deprecated Hydra Confluence Space, and this Page did not appear to be migrated within the Samvera Space).